### PR TITLE
Change package name to match soname

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,11 @@
-intel-level-zero-gpu-raytracing (1.0.0-0ubuntu1~24.04~ppa4) noble; urgency=medium
+intel-level-zero-gpu-raytracing (1.0.0-0ubuntu1~24.10~ppa5) oracular; urgency=medium
+
+  * Change package name to fit soname
+  * Create noble version
+
+ -- Shane McKee <shane.mckee@canonical.com>  Wed, 29 Jan 2025 11:15:53 +0800
+
+intel-level-zero-gpu-raytracing (1.0.0-0ubuntu1~24.10~ppa4) oracular; urgency=medium
 
   * Remove pkg compression override and drop 3rd party docs
 

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,8 @@ Build-Depends: debhelper (>= 11),
 Standards-Version: 4.3.0
 Homepage: https://github.com/intel/level-zero-raytracing-support
 
-Package: intel-level-zero-gpu-raytracing
+Package: libze-intel-gpu-raytracing
+Replaces: intel-level-zero-gpu-raytracing (>= 1.0.0-0ubuntu1~24.10~ppa4)
 Architecture: amd64
 Depends:
  ${misc:Depends},

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Homepage: https://github.com/intel/level-zero-raytracing-support
 
 Package: libze-intel-gpu-raytracing
 Replaces: intel-level-zero-gpu-raytracing (>= 1.0.0-0ubuntu1~24.10~ppa4)
+Conflicts: intel-level-zero-gpu-raytracing
 Architecture: amd64
 Depends:
  ${misc:Depends},

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Standards-Version: 4.3.0
 Homepage: https://github.com/intel/level-zero-raytracing-support
 
 Package: libze-intel-gpu-raytracing
-Replaces: intel-level-zero-gpu-raytracing (>= 1.0.0-0ubuntu1~24.10~ppa4)
+Replaces: intel-level-zero-gpu-raytracing
 Conflicts: intel-level-zero-gpu-raytracing
 Architecture: amd64
 Depends:

--- a/debian/intel-level-zero-gpu-raytracing.lintian-overrides
+++ b/debian/intel-level-zero-gpu-raytracing.lintian-overrides
@@ -1,3 +1,2 @@
-package-name-doesnt-match-sonames libze-intel-gpu-raytracing
 shared-library-lacks-version
 no-symbols-control-file usr/lib/x86_64-linux-gnu/libze_intel_gpu_raytracing.so


### PR DESCRIPTION
Hector pointed out that this was mismatched, and we originally underestimated how standard this is. With level zero being libze, I think this name is also pretty clear 